### PR TITLE
Add ifdef to SF2000

### DIFF
--- a/input.c
+++ b/input.c
@@ -23,7 +23,9 @@ bool libretro_supports_bitmasks    = false;
 bool libretro_supports_ff_override = false;
 bool libretro_ff_enabled           = false;
 bool libretro_ff_enabled_prev      = false;
+#ifdef SF2000
 bool mappingYXtoLR                 = false;
+#endif
 
 unsigned turbo_period      = TURBO_PERIOD_MIN;
 unsigned turbo_pulse_width = TURBO_PULSE_WIDTH_MIN;
@@ -84,6 +86,7 @@ u32 update_input(void)
       libretro_ff_enabled = libretro_supports_ff_override &&
             (ret & (1 << RETRO_DEVICE_ID_JOYPAD_R2));
 
+      #ifdef SF2000
       if (mappingYXtoLR) 
       {
         if (ret & (1 << RETRO_DEVICE_ID_JOYPAD_X))
@@ -93,9 +96,12 @@ u32 update_input(void)
       }
       else
       {
+      #endif
         turbo_a = (ret & (1 << RETRO_DEVICE_ID_JOYPAD_X));
         turbo_b = (ret & (1 << RETRO_DEVICE_ID_JOYPAD_Y));
+      #if defined SF2000
       }
+      #endif
    }
    else
    {
@@ -105,6 +111,7 @@ u32 update_input(void)
        libretro_ff_enabled = libretro_supports_ff_override &&
             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2);
 
+      #ifdef SF2000
       if (mappingYXtoLR) 
       {
         if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))
@@ -114,9 +121,12 @@ u32 update_input(void)
       }
       else
       {
+      #endif
         turbo_a = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
         turbo_b = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
+      #if defined SF2000
       }
+      #endif
    }
 
    /* Handle turbo buttons */

--- a/input.h
+++ b/input.h
@@ -68,7 +68,9 @@ extern bool libretro_ff_enabled_prev;
 #define TURBO_PULSE_WIDTH_MIN 2
 #define TURBO_PULSE_WIDTH_MAX 15
 
+#ifdef SF2000
 extern bool mappingYXtoLR;
+#endif
 
 extern unsigned turbo_period;
 extern unsigned turbo_pulse_width;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -981,6 +981,7 @@ static void check_variables(bool started_from_load)
        (post_process_mix != post_process_mix_prev))
       init_post_processing();
 
+   #ifdef SF2000
    var.key                = "gpsp_mappingYXtoLR";
    var.value              = 0;
    mappingYXtoLR          = false;
@@ -990,6 +991,7 @@ static void check_variables(bool started_from_load)
       if (!strcmp(var.value, "enabled"))
          mappingYXtoLR = true;
    }
+   #endif
    
    var.key           = "gpsp_turbo_period";
    var.value         = NULL;

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -216,6 +216,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   #if defined SF2000
    {
       "gpsp_mappingYXtoLR",
       "Mapping Y X button to L R",
@@ -227,6 +228,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   #endif
    {
       "gpsp_turbo_period",
       "Turbo Button Period",


### PR DESCRIPTION
Add ifdef condition for new configuration variable "gpsp_mappingYXtoLR", this configuration variable only use in SF2000.
In the system with retroarch gui is posible mapping button in the control meu
